### PR TITLE
Add support for zstd/zstandard compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ What's supported:
     - Grayscale and RGB color spaces     
 - Decoding:
     - multiple Image core elements from a monolithic XISF file
-    - Support all standard compression codecs defined in this specification for decompression (zlib/lz4[hc]+
+    - Support all standard compression codecs defined in this specification for decompression (zlib/lz4[hc]/zstd+
       byte shuffling)
 - Encoding:
     - Single image core element with an attached data block
-    - Support all standard compression codecs defined in this specification for decompression (zlib/lz4[hc]+
+    - Support all standard compression codecs defined in this specification for decompression (zlib/lz4[hc]/zstd+
       byte shuffling)
 - "Atomic" properties only (scalar types, String, TimePoint)
 - Metadata and FITSKeyword core elements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "lz4",
+    "zstandard",
 ]
 dynamic = ["version"]
 

--- a/src/xisf.py
+++ b/src/xisf.py
@@ -155,6 +155,8 @@ class XISF:
 
             # Get XISF (XML) Header
             self._xisf_header = f.read(self._headerlength)
+            # Strip possible padding null bytes from the end
+            self._xisf_header = self._xisf_header.split(b'\x00',1)[0]
             self._xisf_header_xml = ET.fromstring(self._xisf_header)
         self._analyze_header()
 
@@ -696,7 +698,7 @@ class XISF:
 
         if codec.startswith("lz4"):
             data = lz4.block.decompress(data, uncompressed_size=uncompressed_size)
-        if codec.startswith("zstd"):
+        elif codec.startswith("zstd"):
             data = zstandard.decompress(data, max_output_size=uncompressed_size)
         elif codec.startswith("zlib"):
             data = zlib.decompress(data)

--- a/src/xisf.py
+++ b/src/xisf.py
@@ -155,11 +155,6 @@ class XISF:
 
             # Get XISF (XML) Header
             self._xisf_header = f.read(self._headerlength)
-            
-            # Strip possible padding null bytes from the end as inserted by libXISF
-            # (https://gitea.nouspiro.space/nou/libXISF)
-            self._xisf_header = self._xisf_header.rstrip(b'\x00')
-
             self._xisf_header_xml = ET.fromstring(self._xisf_header)
         self._analyze_header()
 

--- a/src/xisf.py
+++ b/src/xisf.py
@@ -27,6 +27,7 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import lz4.block # https://python-lz4.readthedocs.io/en/stable/lz4.block.html
 import zlib # https://docs.python.org/3/library/zlib.html
+import zstandard # https://python-zstandard.readthedocs.io/en/stable/
 import base64
 import sys
 from datetime import datetime
@@ -110,7 +111,8 @@ class XISF:
     _compression_def_level = {
         'zlib':  6, # 1..9, default: 6 as indicated in https://docs.python.org/3/library/zlib.html
         'lz4':   0, # no other values, as indicated in https://python-lz4.readthedocs.io/en/stable/lz4.block.html
-        'lz4hc': 9  # 1..12, (4-9 recommended), default: 9 as indicated in https://python-lz4.readthedocs.io/en/stable/lz4.block.html
+        'lz4hc': 9, # 1..12, (4-9 recommended), default: 9 as indicated in https://python-lz4.readthedocs.io/en/stable/lz4.block.html
+        'zstd':  3  # 1..22, (3-9 recommended), default: 3 as indicated in https://facebook.github.io/zstd/zstd_manual.html
     }
 
     def __init__(self, fname):
@@ -378,10 +380,11 @@ class XISF:
             image_metadata: dict with the same structure described for m_i in get_images_metadata(). 
               Only 'FITSKeywords' and 'XISFProperties' keys are actually written, the rest are derived from im_data.
             xisf_metadata: file metadata, dict with the same structure returned by get_file_metadata()
-            codec: compression codec ('zlib', 'lz4' or 'lz4hc'), or None to disable compression
-            shuffle: whether to apply byte-shuffling before compression (ignored if codec is None). Recommended 
-              for 'lz4' and 'lz4hc' compression algorithms.         
-            level: for zlib, 1..9 (default: 6); for lz4hc, 1..12 (default: 9). Higher means more compression.
+            codec: compression codec ('zlib', 'lz4', 'lz4hc' or 'zstd'), or None to disable compression
+            shuffle: whether to apply byte-shuffling before compression (ignored if codec is None). Recommended
+              for 'lz4' ,'lz4hc' and 'zstd' compression algorithms.
+            level: for zlib, 1..9 (default: 6); for lz4hc, 1..12 (default: 9); for zstd, 1..22 (default: 3).
+              Higher means more compression.
         Returns:
             bytes_written: the total number of bytes written into the output file. 
             codec: The codec actually used, i.e., None if compression did not reduce the data block size so
@@ -685,7 +688,7 @@ class XISF:
         return np.transpose(a).tobytes()         
 
 
-    # LZ4/zlib decompression
+    # LZ4/zlib/zstd decompression
     @staticmethod
     def _decompress(data, elem):
         # (codec, uncompressed-size, item-size); item-size is None if not using byte shuffling
@@ -693,6 +696,8 @@ class XISF:
 
         if codec.startswith("lz4"):
             data = lz4.block.decompress(data, uncompressed_size=uncompressed_size)
+        if codec.startswith("zstd"):
+            data = zstandard.decompress(data, max_output_size=uncompressed_size)
         elif codec.startswith("zlib"):
             data = zlib.decompress(data)
         else:
@@ -704,7 +709,7 @@ class XISF:
         return data
 
 
-    # LZ4/zlib compression
+    # LZ4/zlib/zstd compression
     @staticmethod
     def _compress(data, codec, level=None, shuffle=False, itemsize=None):
         compressed = XISF._shuffle(data, itemsize) if shuffle else data
@@ -719,6 +724,9 @@ class XISF:
             ) 
         elif codec == 'lz4':
             compressed = lz4.block.compress(compressed, store_size=False) 
+        elif codec == 'zstd':
+            level = level if level else XISF._compression_def_level['zstd']
+            compressed = zstandard.compress(compressed, level=level)
         elif codec == 'zlib':
             level = level if level else XISF._compression_def_level['zlib']
             compressed = zlib.compress(compressed, level=level)

--- a/src/xisf.py
+++ b/src/xisf.py
@@ -155,8 +155,11 @@ class XISF:
 
             # Get XISF (XML) Header
             self._xisf_header = f.read(self._headerlength)
-            # Strip possible padding null bytes from the end
-            self._xisf_header = self._xisf_header.split(b'\x00',1)[0]
+            
+            # Strip possible padding null bytes from the end as inserted by libXISF
+            # (https://gitea.nouspiro.space/nou/libXISF)
+            self._xisf_header = self._xisf_header.rstrip(b'\x00')
+
             self._xisf_header_xml = ET.fromstring(self._xisf_header)
         self._analyze_header()
 


### PR DESCRIPTION
Hi and thanks for a wonderful library! PixInsight added support for zstd compression in version 1.8.9-2 and I've been using it also when shooting as INDI also supports it now.

I've been using GraXpert (https://www.graxpert.com/) for gradient removal and noticed it didn't want to load my new images anymore. I noticed it uses your library so I added the trivial missing pieces for zstd compression and now I'm happy again :)

The XISF changes were documented in https://pixinsight.com/forum/index.php?threads/xisf-standard-revision-re-zstd.21230/